### PR TITLE
[semver:patch] curl arg limit fix

### DIFF
--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -35,10 +35,10 @@ PostToSlack() {
     do
         echo "Sending to Slack Channel: $i"
         SLACK_MSG_BODY=$(echo "$SLACK_MSG_BODY" | jq --arg channel "$i" '.channel = $channel')
-        curl -s -f -X POST -H 'Content-type: application/json' \
+        echo "$SLACK_MSG_BODY" | curl -s -f -X POST -H 'Content-type: application/json' \
         -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" \
-        --data \
-        "$SLACK_MSG_BODY" https://slack.com/api/chat.postMessage > /dev/null
+        --data @- \
+        https://slack.com/api/chat.postMessage > /dev/null
     done
 }
 


### PR DESCRIPTION
Uses stdin as the input for curl POST data.  This avoids errors with post data that exceeds the Linux MAX_ARG_STRLEN value of 131072 bytes.  The message will still be truncated by Slack if it exceeds 40,000 characters, but the job will not fail. 

If longer messages are needed, one viable solution is to direct them to a file and store as an artifact.